### PR TITLE
Remove header allocations

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -98,7 +98,9 @@ type Decoder struct {
 
 // Decoded is the old type name for the Decoder
 // DEPRECATED
-type Decoded Decoder
+type Decoded struct {
+	*Decoder
+}
 
 func (d *Decoder) readFrame() error {
 	var err error

--- a/decode.go
+++ b/decode.go
@@ -238,6 +238,6 @@ func Decode(r io.ReadCloser) (*Decoded, error) {
 	if err := d.readFrame(); err != nil {
 		return nil, err
 	}
-	d.sampleRate = samplingFrequency[d.frame.header.sampling_frequency]
+	d.sampleRate = samplingFrequency[d.frame.header.SamplingFrequency()]
 	return d, nil
 }

--- a/decode.go
+++ b/decode.go
@@ -83,10 +83,10 @@ func (s *source) getFilepos() int64 {
 	return s.pos
 }
 
-// A Decoded is a MP3-decoded stream.
+// A Decoder is a MP3-decoded stream.
 //
-// Decoded decodes its underlying source on the fly.
-type Decoded struct {
+// Decoder decodes its underlying source on the fly.
+type Decoder struct {
 	source      *source
 	sampleRate  int
 	length      int64
@@ -96,7 +96,7 @@ type Decoded struct {
 	pos         int64
 }
 
-func (d *Decoded) readFrame() error {
+func (d *Decoder) readFrame() error {
 	var err error
 	d.frame, _, err = d.source.readNextFrame(d.frame)
 	if err != nil {
@@ -114,7 +114,7 @@ func (d *Decoded) readFrame() error {
 }
 
 // Read is io.Reader's Read.
-func (d *Decoded) Read(buf []uint8) (int, error) {
+func (d *Decoder) Read(buf []uint8) (int, error) {
 	for len(d.buf) == 0 {
 		if err := d.readFrame(); err != nil {
 			return 0, err
@@ -129,7 +129,7 @@ func (d *Decoded) Read(buf []uint8) (int, error) {
 // Seek is io.Seeker's Seek.
 //
 // Seek panics when the underlying source is not io.Seeker.
-func (d *Decoded) Seek(offset int64, whence int) (int64, error) {
+func (d *Decoder) Seek(offset int64, whence int) (int64, error) {
 	s, ok := d.source.reader.(io.Seeker)
 	if !ok {
 		panic("mp3: d.reader must be io.Seeker")
@@ -176,14 +176,14 @@ func (d *Decoded) Seek(offset int64, whence int) (int64, error) {
 }
 
 // Close is io.Closer's Close.
-func (d *Decoded) Close() error {
+func (d *Decoder) Close() error {
 	return d.source.Close()
 }
 
 // SampleRate returns the sample rate like 44100.
 //
 // Note that the sample rate is retrieved from the first frame.
-func (d *Decoded) SampleRate() int {
+func (d *Decoder) SampleRate() int {
 	return d.sampleRate
 }
 
@@ -191,22 +191,22 @@ func (d *Decoded) SampleRate() int {
 //
 // Length returns -1 when the total size is not available
 // e.g. when the given source is not io.Seeker.
-func (d *Decoded) Length() int64 {
+func (d *Decoder) Length() int64 {
 	return d.length
 }
 
-// Decode decodes the given io.ReadCloser and returns a decoded stream.
+// NewDecoder decodes the given io.ReadCloser and returns a decoded stream.
 //
 // The stream is always formatted as 16bit (little endian) 2 channels
 // even if the source is single channel MP3.
 // Thus, a sample always consists of 4 bytes.
 //
 // If r is io.Seeker, a decoded stream checks its length and Length returns a valid value.
-func Decode(r io.ReadCloser) (*Decoded, error) {
+func NewDecoder(r io.ReadCloser) (*Decoder, error) {
 	s := &source{
 		reader: r,
 	}
-	d := &Decoded{
+	d := &Decoder{
 		source: s,
 		length: -1,
 	}
@@ -240,4 +240,10 @@ func Decode(r io.ReadCloser) (*Decoded, error) {
 	}
 	d.sampleRate = samplingFrequency[d.frame.header.SamplingFrequency()]
 	return d, nil
+}
+
+// Decode is here for compatibility purposes so as to not break the existing API. Use NewDecoder instead.
+// DEPRECATED
+func Decode(r io.ReadCloser) (*Decoder, error) {
+	return NewDecoder(r)
 }

--- a/decode.go
+++ b/decode.go
@@ -96,6 +96,10 @@ type Decoder struct {
 	pos         int64
 }
 
+// Decoded is the old type name for the Decoder
+// DEPRECATED
+type Decoded Decoder
+
 func (d *Decoder) readFrame() error {
 	var err error
 	d.frame, _, err = d.source.readNextFrame(d.frame)

--- a/fuzzing_test.go
+++ b/fuzzing_test.go
@@ -78,6 +78,6 @@ func TestFuzzingIssue3(t *testing.T) {
 	}
 	for _, input := range inputs {
 		b := &bytesReadCloser{bytes.NewReader([]uint8(input))}
-		_, _ = Decode(b)
+		_, _ = NewDecoder(b)
 	}
 }

--- a/l3.go
+++ b/l3.go
@@ -97,7 +97,7 @@ var (
 
 func (f *frame) l3Requantize(gr int, ch int) {
 	// Setup sampling frequency index
-	sfreq := f.header.sampling_frequency
+	sfreq := f.header.SamplingFrequency()
 	// Determine type of block to process
 	if (f.sideInfo.win_switch_flag[gr][ch] == 1) && (f.sideInfo.block_type[gr][ch] == 2) { // Short blocks
 		// Check if the first two subbands
@@ -172,7 +172,7 @@ func (f *frame) l3Requantize(gr int, ch int) {
 func (f *frame) l3Reorder(gr int, ch int) {
 	re := make([]float32, samplesPerGr)
 
-	sfreq := f.header.sampling_frequency // Setup sampling freq index
+	sfreq := f.header.SamplingFrequency() // Setup sampling freq index
 	// Only reorder short blocks
 	if (f.sideInfo.win_switch_flag[gr][ch] == 1) && (f.sideInfo.block_type[gr][ch] == 2) { // Short blocks
 		// Check if the first two subbands
@@ -227,7 +227,7 @@ func (f *frame) stereoProcessIntensityLong(gr int, sfb int) {
 	// Check that((is_pos[sfb]=scalefac) != 7) => no intensity stereo
 	is_pos := f.mainData.scalefac_l[gr][0][sfb]
 	if is_pos != 7 {
-		sfreq := f.header.sampling_frequency // Setup sampling freq index
+		sfreq := f.header.SamplingFrequency() // Setup sampling freq index
 		sfb_start := sfBandIndicesSet[sfreq].l[sfb]
 		sfb_stop := sfBandIndicesSet[sfreq].l[sfb+1]
 		if is_pos == 6 { // tan((6*PI)/12 = PI/2) needs special treatment!
@@ -248,7 +248,7 @@ func (f *frame) stereoProcessIntensityLong(gr int, sfb int) {
 func (f *frame) stereoProcessIntensityShort(gr int, sfb int) {
 	is_ratio_l := float32(0)
 	is_ratio_r := float32(0)
-	sfreq := f.header.sampling_frequency // Setup sampling freq index
+	sfreq := f.header.SamplingFrequency() // Setup sampling freq index
 	// The window length
 	win_len := sfBandIndicesSet[sfreq].s[sfb+1] - sfBandIndicesSet[sfreq].s[sfb]
 	// The three windows within the band has different scalefactors
@@ -277,11 +277,11 @@ func (f *frame) stereoProcessIntensityShort(gr int, sfb int) {
 
 func (f *frame) l3Stereo(gr int) {
 	// Do nothing if joint stereo is not enabled
-	if (f.header.mode != 1) || (f.header.mode_extension == 0) {
+	if (f.header.Mode() != 1) || (f.header.ModeExtension() == 0) {
 		return
 	}
 	// Do Middle/Side("normal") stereo processing
-	if (f.header.mode_extension & 0x2) != 0 {
+	if (f.header.ModeExtension() & 0x2) != 0 {
 		// Determine how many frequency lines to transform
 		i := 0
 		if f.sideInfo.count1[gr][0] > f.sideInfo.count1[gr][1] {
@@ -298,9 +298,9 @@ func (f *frame) l3Stereo(gr int) {
 		}
 	}
 	// Do intensity stereo processing
-	if (f.header.mode_extension & 0x1) != 0 {
+	if (f.header.ModeExtension() & 0x1) != 0 {
 		// Setup sampling frequency index
-		sfreq := f.header.sampling_frequency
+		sfreq := f.header.SamplingFrequency()
 		// First band that is intensity stereo encoded is first band scale factor
 		// band on or above count1 frequency line. N.B.: Intensity stereo coding is
 		// only done for higher subbands, but logic is here for lower subbands.

--- a/maindata.go
+++ b/maindata.go
@@ -41,7 +41,7 @@ func (s *source) readMainL3(prev *bits.Bits, header *mpeg1FrameHeader, sideInfo 
 	// Main data size is the rest of the frame,including ancillary data
 	main_data_size := framesize - sideinfo_size - 4 // sync+header
 	// CRC is 2 bytes
-	if header.protection_bit == 0 {
+	if header.ProtectionBit() == 0 {
 		main_data_size -= 2
 	}
 	// Assemble main data buffer with data from this frame and the previous

--- a/read.go
+++ b/read.go
@@ -132,7 +132,7 @@ func (s *source) readHeader() (h *mpeg1FrameHeader, startPosition int64, err err
 	}
 	// If we get here we've found the sync word,and can decode the header
 	// which is in the low 20 bits of the 32-bit sync+header word.
-	// Decode the header
+	// NewDecoder the header
 	head := mpeg1FrameHeader(header)
 
 	// Check for invalid values and impossible combinations

--- a/sideinfo.go
+++ b/sideinfo.go
@@ -36,7 +36,7 @@ func (src *source) readSideInfo(header *mpeg1FrameHeader) (*mpeg1SideInfo, error
 	// Main data size is the rest of the frame,including ancillary data
 	main_data_size := framesize - sideinfo_size - 4 // sync+header
 	// CRC is 2 bytes
-	if header.protection_bit == 0 {
+	if header.ProtectionBit() == 0 {
 		main_data_size -= 2
 	}
 	// Read sideinfo from bitstream into buffer used by Bits()
@@ -49,7 +49,7 @@ func (src *source) readSideInfo(header *mpeg1FrameHeader) (*mpeg1SideInfo, error
 	si := &mpeg1SideInfo{}
 	si.main_data_begin = s.Bits(9)
 	// Get private bits. Not used for anything.
-	if header.mode == mpeg1ModeSingleChannel {
+	if header.Mode() == mpeg1ModeSingleChannel {
 		si.private_bits = s.Bits(5)
 	} else {
 		si.private_bits = s.Bits(3)

--- a/types.go
+++ b/types.go
@@ -14,9 +14,7 @@
 
 package mp3
 
-import (
-	"github.com/hajimehoshi/go-mp3/internal/bits"
-)
+import "github.com/hajimehoshi/go-mp3/internal/bits"
 
 type mpeg1Layer int
 
@@ -37,19 +35,54 @@ const (
 )
 
 // A mepg1FrameHeader is MPEG1 Layer 1-3 frame header
-type mpeg1FrameHeader struct {
-	id                 int        // 1 bit
-	layer              mpeg1Layer // 2 bits
-	protection_bit     int        // 1 bit
-	bitrate_index      int        // 4 bits
-	sampling_frequency int        // 2 bits
-	padding_bit        int        // 1 bit
-	private_bit        int        // 1 bit
-	mode               mpeg1Mode  // 2 bits
-	mode_extension     int        // 2 bits
-	copyright          int        // 1 bit
-	original_or_copy   int        // 1 bit
-	emphasis           int        // 2 bits
+type mpeg1FrameHeader int
+
+func (m mpeg1FrameHeader) ID() int {
+	return int((m & 0x00180000) >> 19)
+}
+
+func (m mpeg1FrameHeader) Layer() mpeg1Layer {
+	return mpeg1Layer((m & 0x00060000) >> 17)
+}
+
+func (m mpeg1FrameHeader) ProtectionBit() int {
+	return int(m&0x00010000) >> 16
+}
+
+func (m mpeg1FrameHeader) BitrateIndex() int {
+	return int(m&0x0000f000) >> 12
+}
+
+func (m mpeg1FrameHeader) SamplingFrequency() int {
+	return int(m&0x00000c00) >> 10
+}
+
+func (m mpeg1FrameHeader) PaddingBit() int {
+	return int(m&0x00000200) >> 9
+}
+
+func (m mpeg1FrameHeader) PrivateBit() int {
+	return int(m&0x00000100) >> 8
+}
+
+func (m mpeg1FrameHeader) Mode() mpeg1Mode {
+	return mpeg1Mode((m & 0x000000c0) >> 6)
+}
+
+func (m mpeg1FrameHeader) ModeExtension() int {
+	return int(m&0x00000030) >> 4
+}
+
+func (m mpeg1FrameHeader) Copyright() int {
+	return int(m&0x00000008) >> 3
+}
+
+func (m mpeg1FrameHeader) OriginalOrCopy() int {
+	return int(m&0x00000004) >> 2
+}
+
+func (m mpeg1FrameHeader) Emphasis() int {
+	return int(m&0x00000003) >> 0
 }
 
 // A mpeg1SideInfo is  MPEG1 Layer 3 Side Information.
@@ -113,13 +146,13 @@ var mpeg1Bitrates = map[mpeg1Layer][15]int{
 var samplingFrequency = []int{44100, 48000, 32000}
 
 func (h *mpeg1FrameHeader) frameSize() int {
-	return (144*mpeg1Bitrates[h.layer][h.bitrate_index])/
-		samplingFrequency[h.sampling_frequency] +
-		int(h.padding_bit)
+	return (144*mpeg1Bitrates[h.Layer()][h.BitrateIndex()])/
+		samplingFrequency[h.SamplingFrequency()] +
+		int(h.PaddingBit())
 }
 
 func (h *mpeg1FrameHeader) numberOfChannels() int {
-	if h.mode == mpeg1ModeSingleChannel {
+	if h.Mode() == mpeg1ModeSingleChannel {
 		return 1
 	}
 	return 2

--- a/types.go
+++ b/types.go
@@ -37,50 +37,63 @@ const (
 // A mepg1FrameHeader is MPEG1 Layer 1-3 frame header
 type mpeg1FrameHeader int
 
+// ID returns this header's ID stored in position 20,19
 func (m mpeg1FrameHeader) ID() int {
 	return int((m & 0x00180000) >> 19)
 }
 
+// Layer returns the mpeg layer of this frame stored in position 18,17
 func (m mpeg1FrameHeader) Layer() mpeg1Layer {
 	return mpeg1Layer((m & 0x00060000) >> 17)
 }
 
+// ProtectionBit returns the protection bit stored in position 16
 func (m mpeg1FrameHeader) ProtectionBit() int {
 	return int(m&0x00010000) >> 16
 }
 
+// BirateIndex returns the bitrate index stored in position 15,12
 func (m mpeg1FrameHeader) BitrateIndex() int {
 	return int(m&0x0000f000) >> 12
 }
 
+// SamplingFrequency returns the SamplingFrequency in Hz stored in position 11,10
 func (m mpeg1FrameHeader) SamplingFrequency() int {
 	return int(m&0x00000c00) >> 10
 }
 
+// PaddingBit returns the padding bit stored in position 9
 func (m mpeg1FrameHeader) PaddingBit() int {
 	return int(m&0x00000200) >> 9
 }
 
+// PrivateBit returns the private bit stored in position 8 - this bit may be used to store arbitrary data to be used
+// by an application
 func (m mpeg1FrameHeader) PrivateBit() int {
 	return int(m&0x00000100) >> 8
 }
 
+// Mode returns the channel mode, stored in position 7,6
 func (m mpeg1FrameHeader) Mode() mpeg1Mode {
 	return mpeg1Mode((m & 0x000000c0) >> 6)
 }
 
+// ModeExtension returns the mode_extension - for use with Joint Stereo - stored in position 4,5
 func (m mpeg1FrameHeader) ModeExtension() int {
 	return int(m&0x00000030) >> 4
 }
 
+// Copyright returns whether or not this recording is copywritten - stored in position 3
 func (m mpeg1FrameHeader) Copyright() int {
 	return int(m&0x00000008) >> 3
 }
 
+// OriginalOrCopy returns whether or not this is an Original recording or a copy of one - stored in position 2
 func (m mpeg1FrameHeader) OriginalOrCopy() int {
 	return int(m&0x00000004) >> 2
 }
 
+// Emphasis returns emphasis - the emphasis indication is here to tell the decoder that the file must be de-emphasized - stored in position 0,1
 func (m mpeg1FrameHeader) Emphasis() int {
 	return int(m&0x00000003) >> 0
 }


### PR DESCRIPTION
Removes header allocations and adds convenience functions for the header, speeding up the decoding process (and eliminating some stutter when playing back with oto under certain conditions)