### PR TITLE
Expose NumberOfChannels method

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -34,6 +34,7 @@ type Decoder struct {
 	buf         []byte
 	frame       *frame.Frame
 	pos         int64
+	channels    int
 }
 
 func (d *Decoder) readFrame() error {
@@ -123,6 +124,11 @@ func (d *Decoder) SampleRate() int {
 	return d.sampleRate
 }
 
+// NumberOfChannels returns the number of audio channels.
+func (d *Decoder) NumberOfChannels() int {
+	return d.channels
+}
+
 func (d *Decoder) ensureFrameStartsAndLength() error {
 	if d.length != invalidLength {
 		return nil
@@ -208,6 +214,7 @@ func NewDecoder(r io.ReadCloser) (*Decoder, error) {
 		return nil, err
 	}
 	d.sampleRate = d.frame.SamplingFrequency()
+	d.channels = d.frame.NumberOfChannels()
 
 	if err := d.ensureFrameStartsAndLength(); err != nil {
 		return nil, err

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -115,6 +115,10 @@ func (f *Frame) SamplingFrequency() int {
 	return f.header.SamplingFrequency().Int()
 }
 
+func (f *Frame) NumberOfChannels() int {
+	return f.header.NumberOfChannels()
+}
+
 func (f *Frame) Decode() []byte {
 	out := make([]byte, consts.BytesPerFrame)
 	nch := f.header.NumberOfChannels()


### PR DESCRIPTION
Having this information would allow this package to be used in conjunction with the `azul3d.org/engine/audio` package; as this is required information for any Decoder.

References:
- https://godoc.org/azul3d.org/engine/audio#Decoder
- https://godoc.org/azul3d.org/engine/audio#Config