### PR TITLE
Use io.ReadSeeker instead of io.ReadCloser

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -26,7 +26,7 @@ func BenchmarkDecode(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	src := &bytesReadCloser{bytes.NewReader(buf)}
+	src := bytes.NewReader(buf)
 	for i := 0; i < b.N; i++ {
 		if _, err := src.Seek(0, io.SeekStart); err != nil {
 			b.Fatal(err)

--- a/decode.go
+++ b/decode.go
@@ -186,7 +186,7 @@ func (d *Decoder) Length() int64 {
 // The stream is always formatted as 16bit (little endian) 2 channels
 // even if the source is single channel MP3.
 // Thus, a sample always consists of 4 bytes.
-func NewDecoder(r io.ReadSeeker) (*Decoder, error) {
+func NewDecoder(r io.Reader) (*Decoder, error) {
 	s := &source{
 		reader: r,
 	}

--- a/decode.go
+++ b/decode.go
@@ -111,6 +111,11 @@ func (d *Decoder) Seek(offset int64, whence int) (int64, error) {
 	return npos, nil
 }
 
+// Close is io.Closer's Close. Close does nothing and always returns nil.
+func (d *Decoder) Close() error {
+	return nil
+}
+
 // SampleRate returns the sample rate like 44100.
 //
 // Note that the sample rate is retrieved from the first frame.

--- a/decode.go
+++ b/decode.go
@@ -181,7 +181,7 @@ func (d *Decoder) Length() int64 {
 	return d.length
 }
 
-// NewDecoder decodes the given io.ReadSeeker and returns a decoded stream.
+// NewDecoder decodes the given io.Reader and returns a decoded stream.
 //
 // The stream is always formatted as 16bit (little endian) 2 channels
 // even if the source is single channel MP3.

--- a/decode.go
+++ b/decode.go
@@ -111,11 +111,6 @@ func (d *Decoder) Seek(offset int64, whence int) (int64, error) {
 	return npos, nil
 }
 
-// Close is io.Closer's Close.
-func (d *Decoder) Close() error {
-	return d.source.Close()
-}
-
 // SampleRate returns the sample rate like 44100.
 //
 // Note that the sample rate is retrieved from the first frame.
@@ -186,12 +181,12 @@ func (d *Decoder) Length() int64 {
 	return d.length
 }
 
-// NewDecoder decodes the given io.ReadCloser and returns a decoded stream.
+// NewDecoder decodes the given io.ReadSeeker and returns a decoded stream.
 //
 // The stream is always formatted as 16bit (little endian) 2 channels
 // even if the source is single channel MP3.
 // Thus, a sample always consists of 4 bytes.
-func NewDecoder(r io.ReadCloser) (*Decoder, error) {
+func NewDecoder(r io.ReadSeeker) (*Decoder, error) {
 	s := &source{
 		reader: r,
 	}

--- a/fuzzing_test.go
+++ b/fuzzing_test.go
@@ -19,14 +19,6 @@ import (
 	"testing"
 )
 
-type bytesReadCloser struct {
-	*bytes.Reader
-}
-
-func (b *bytesReadCloser) Close() error {
-	return nil
-}
-
 func TestFuzzing(t *testing.T) {
 	inputs := []string{
 		// #3
@@ -109,7 +101,7 @@ func TestFuzzing(t *testing.T) {
 			"0000000000000",
 	}
 	for _, input := range inputs {
-		b := &bytesReadCloser{bytes.NewReader([]byte(input))}
+		b := bytes.NewReader([]byte(input))
 		_, _ = NewDecoder(b)
 	}
 }

--- a/source.go
+++ b/source.go
@@ -19,28 +19,18 @@ import (
 )
 
 type source struct {
-	reader io.ReadCloser
+	reader io.ReadSeeker
 	buf    []byte
 	pos    int64
 }
 
 func (s *source) Seek(position int64, whence int) (int64, error) {
-	seeker, ok := s.reader.(io.Seeker)
-	if !ok {
-		panic("mp3: source must be io.Seeker")
-	}
-	s.buf = nil
-	n, err := seeker.Seek(position, whence)
+	n, err := s.reader.Seek(position, whence)
 	if err != nil {
 		return 0, err
 	}
 	s.pos = n
 	return n, nil
-}
-
-func (s *source) Close() error {
-	s.buf = nil
-	return s.reader.Close()
 }
 
 func (s *source) skipTags() error {

--- a/source.go
+++ b/source.go
@@ -19,13 +19,18 @@ import (
 )
 
 type source struct {
-	reader io.ReadSeeker
+	reader io.Reader
 	buf    []byte
 	pos    int64
 }
 
 func (s *source) Seek(position int64, whence int) (int64, error) {
-	n, err := s.reader.Seek(position, whence)
+	seeker, ok := s.reader.(io.Seeker)
+	if !ok {
+		panic("mp3: source must be io.Seeker")
+	}
+	s.buf = nil
+	n, err := seeker.Seek(position, whence)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Current implementation requires io.ReadCloser interface to create Decoder. Internally, there is no calls to Close method, so this dependency isn't really necessary. But, decoder implicitly requires io.Seeker, otherwise panic happens. With this pull request I address next points: 

1. Make io.ReadSeeker dependency explicit.
2. Remove Close method, as it will be handled by the code that provides source (the caller). This also allow us to use Decoder with sources that don't implement io.Closer.