### PR TITLE
Shortcut asking Decoder for current position

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -15,7 +15,7 @@
 package mp3
 
 import (
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/hajimehoshi/go-mp3/internal/consts"
@@ -89,7 +89,7 @@ func (d *Decoder) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekEnd:
 		npos = d.Length() + offset
 	default:
-		panic(fmt.Sprintf("mp3: invalid whence: %v", whence))
+		return 0, errors.New("mp3.Decoder.Seek: invalid whence")
 	}
 	d.pos = npos
 	d.buf = nil

--- a/decode.go
+++ b/decode.go
@@ -70,7 +70,16 @@ func (d *Decoder) Read(buf []byte) (int, error) {
 // Seek is io.Seeker's Seek.
 //
 // Seek panics when the underlying source is not io.Seeker.
+//
+// Note that seek uses a byte offset but samples are aligned to 4 bytes (2
+// channels, 2 bytes each). Be careful to seek to an offset that is divisible by
+// 4 if you want to read at full sample boundaries.
 func (d *Decoder) Seek(offset int64, whence int) (int64, error) {
+	if offset == 0 && whence == io.SeekCurrent {
+		// Handle the special case of asking for the current position specially.
+		return d.pos, nil
+	}
+
 	npos := int64(0)
 	switch whence {
 	case io.SeekStart:

--- a/decode.go
+++ b/decode.go
@@ -69,7 +69,7 @@ func (d *Decoder) Read(buf []byte) (int, error) {
 
 // Seek is io.Seeker's Seek.
 //
-// Seek panics when the underlying source is not io.Seeker.
+// Seek returns an error when the underlying source is not io.Seeker.
 //
 // Note that seek uses a byte offset but samples are aligned to 4 bytes (2
 // channels, 2 bytes each). Be careful to seek to an offset that is divisible by

--- a/decode.go
+++ b/decode.go
@@ -89,7 +89,7 @@ func (d *Decoder) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekEnd:
 		npos = d.Length() + offset
 	default:
-		return 0, errors.New("mp3.Decoder.Seek: invalid whence")
+		return 0, errors.New("mp3: invalid whence")
 	}
 	d.pos = npos
 	d.buf = nil

--- a/internal/sideinfo/sideinfo.go
+++ b/internal/sideinfo/sideinfo.go
@@ -64,7 +64,10 @@ var sideInfoBitsToRead = [2][4]int{
 
 func Read(source FullReader, header frameheader.FrameHeader) (*SideInfo, error) {
 	nch := header.NumberOfChannels()
-	framesize := header.FrameSize()
+	framesize, err := header.FrameSize()
+	if err != nil {
+		return nil, err
+	}
 	if framesize > 2000 {
 		return nil, fmt.Errorf("mp3: framesize = %d\n", framesize)
 	}

--- a/source.go
+++ b/source.go
@@ -28,7 +28,7 @@ type source struct {
 func (s *source) Seek(position int64, whence int) (int64, error) {
 	seeker, ok := s.reader.(io.Seeker)
 	if !ok {
-		return 0, errors.New("mp3.source.Seek: source must be io.Seeker")
+		return 0, errors.New("mp3: source must be io.Seeker")
 	}
 	s.buf = nil
 	n, err := seeker.Seek(position, whence)

--- a/source.go
+++ b/source.go
@@ -15,6 +15,7 @@
 package mp3
 
 import (
+	"errors"
 	"io"
 )
 
@@ -27,7 +28,7 @@ type source struct {
 func (s *source) Seek(position int64, whence int) (int64, error) {
 	seeker, ok := s.reader.(io.Seeker)
 	if !ok {
-		panic("mp3: source must be io.Seeker")
+		return 0, errors.New("mp3.source.Seek: source must be io.Seeker")
 	}
 	s.buf = nil
 	n, err := seeker.Seek(position, whence)


### PR DESCRIPTION
Also improve documentation on Decoder.Seek.

I have ran into the issues when trying to get the current position from the Decoder. I used Seek(0, io.SeekCurrent) but it would result in noise. That is why I added a shortcut.

Another reason I got to hear noise was that I translated mouse clicks from pixels to byte offsets. That is why I added the comment, I needed to seek to the start of a sample.

I am currently replacing my Clementine music player with my own Go mp3 player. It is almost ready to be shared, I will let you know once it is ready. Thank you very much for your work, really great libraries that you create!