### PR TITLE
Fix compiler error

### DIFF
--- a/internal/maindata/maindata.go
+++ b/internal/maindata/maindata.go
@@ -81,7 +81,10 @@ func initSlen() {
 func Read(source FullReader, prev *bits.Bits, header frameheader.FrameHeader, sideInfo *sideinfo.SideInfo) (*MainData, *bits.Bits, error) {
 	nch := header.NumberOfChannels()
 	// Calculate header audio data size
-	framesize := header.FrameSize()
+	framesize, err := header.FrameSize()
+	if err != nil {
+		return nil, nil, err
+	}
 	if framesize > 2000 {
 		return nil, nil, fmt.Errorf("mp3: framesize = %d", framesize)
 	}


### PR DESCRIPTION
I am not sure why this went wrong, but after you merged my PR yesterday, there is now a compile error. This of course did not happen on my machine with my clone. That one `go install`ed just fine. I am not yet used to Go modules, they are hard. I think I might have built my stuff against the wrong version and somehow `go install` inside the mp3 root directory did not really install it. It told me nothing about the error. This is very strange.