### PR TITLE
Fix compile errors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -166,7 +166,11 @@ func (d *Decoder) ensureFrameStartsAndLength() error {
 		d.bytesPerFrame = int64(h.BytesPerFrame())
 		l += d.bytesPerFrame
 
-		buf := make([]byte, h.FrameSize()-4)
+		framesize, err := h.FrameSize()
+		if err != nil {
+			return err
+		}
+		buf := make([]byte, framesize-4)
 		if _, err := d.source.ReadFull(buf); err != nil {
 			if err == io.EOF {
 				break
@@ -213,7 +217,11 @@ func NewDecoder(r io.Reader) (*Decoder, error) {
 	if err := d.readFrame(); err != nil {
 		return nil, err
 	}
-	d.sampleRate = d.frame.SamplingFrequency()
+	freq, err := d.frame.SamplingFrequency()
+	if err != nil {
+		return nil, err
+	}
+	d.sampleRate = freq
 
 	if err := d.ensureFrameStartsAndLength(); err != nil {
 		return nil, err

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -111,7 +111,7 @@ func Read(source FullReader, position int64, prev *Frame) (frame *Frame, startPo
 	return nf, pos, nil
 }
 
-func (f *Frame) SamplingFrequency() int {
+func (f *Frame) SamplingFrequency() (int, error) {
 	return f.header.SamplingFrequencyValue()
 }
 

--- a/internal/maindata/maindata.go
+++ b/internal/maindata/maindata.go
@@ -81,7 +81,10 @@ func initSlen() {
 func Read(source FullReader, prev *bits.Bits, header frameheader.FrameHeader, sideInfo *sideinfo.SideInfo) (*MainData, *bits.Bits, error) {
 	nch := header.NumberOfChannels()
 	// Calculate header audio data size
-	framesize := header.FrameSize()
+	framesize, err := header.FrameSize()
+	if err != nil {
+		return nil, nil, err
+	}
 	if framesize > 2000 {
 		return nil, nil, fmt.Errorf("mp3: framesize = %d", framesize)
 	}


### PR DESCRIPTION
Well, turns out the trick is to run `go install ./...` in the root directory of the repo, once I did that these other compile errors came up. Go modules have already given me a lot of headache, I hope they are worth it in the end...